### PR TITLE
Fix OV version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 transformers>=4.35.2
 sentence-transformers>=2.2.2
-openvino-nightly==2023.3.0.dev20231113
+openvino-nightly>=2023.3.0.dev20231212
 openvino-telemetry==2023.2.1
 optimum==1.14.1
 optimum-intel @ git+https://github.com/huggingface/optimum-intel.git@f248835b16ce4ec054d6d4d629dff4213fe94157


### PR DESCRIPTION
`openvino-nightly==2023.3.0.dev20231113`  version was deleted from https://pypi.org/project/openvino/#history