### PR TITLE
allow lower versions for conformance tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ transformers>=4.35.2
 sentence-transformers>=2.2.2
 openvino>=2023.3.0
 openvino-telemetry==2023.2.1
-optimum>=1.16.1
-optimum-intel[openvino]>=1.13.0
+optimum>=1.16.0
+optimum-intel[openvino]>1.12
 pandas>=2.0.3
 numpy>=1.23.5
 tqdm>=4.66.1


### PR DESCRIPTION
Conformance tests are currently not compatible with WWB, because optimum and optimum-intel of lower version are used.

https://github.com/openvinotoolkit/nncf/blob/develop/tests/post_training/requirements.txt#L11-L12
```python
optimum[onnxruntime,openvino]==1.16.0
optimum-intel @ git+https://github.com/huggingface/optimum-intel@622f585962e5e0ff5f927fd1a96fbc02b60a2e65
```

Propose to lower versions a little bit